### PR TITLE
Check whether pred_times and eval_times are sorted(monotonic order)

### DIFF
--- a/timeseriescv/cross_validation.py
+++ b/timeseriescv/cross_validation.py
@@ -54,6 +54,11 @@ class BaseTimeSeriesCrossValidator:
         if (X.index == eval_times.index).sum() != len(eval_times):
             raise ValueError('X and eval_times must have the same index')
 
+        if not pred_times.equals(pred_times.sort_values()):
+            raise ValueError('pred_times should be sorted')
+        if not eval_times.equals(eval_times.sort_values()):
+            raise ValueError('eval_times should be sorted')
+
         self.pred_times = pred_times
         self.eval_times = eval_times
         self.indices = np.arange(X.shape[0])


### PR DESCRIPTION
I added some checking logic.

Reason:

If `dataframe` could look like this:
```
       store_id cutoff_time  eval_time region           y
31            1  2018-05-01 2018-05-01    NaN  259571.420
32            1  2018-06-01 2018-06-01    NaN  271214.280
33            1  2018-07-01 2018-07-01    NaN  256500.000
34            1  2018-08-01 2018-08-01    NaN  250714.280
35            1  2018-09-01 2018-09-01    NaN  239357.140
36            1  2018-10-01 2018-10-01    NaN  261071.420
37            1  2018-11-01 2018-11-01    NaN  314357.160
38            1  2018-12-01 2018-12-01    NaN  311000.000
37420      2136  2018-06-01 2018-06-01    jeju 5157085.500
37421      2136  2018-07-01 2018-07-01    jeju 5599800.000
37422      2136  2018-08-01 2018-08-01    jeju 6010228.500
37423      2136  2018-09-01 2018-09-01    jeju 6923357.000
37424      2136  2018-10-01 2018-10-01    jeju 6575071.500
37425      2136  2018-11-01 2018-11-01    jeju 6436500.000
37426      2136  2018-12-01 2018-12-01    jeju 6528500.000
```

In this case, `PurgedWalkForwardCV` won't work: It returns not-aligned cv index. This is caused  by `searchsorted` in `compute_fold_bounds()`.

 