### PR TITLE
Fixed bug on embargo where wrong index was being used

### DIFF
--- a/timeseriescv/cross_validation.py
+++ b/timeseriescv/cross_validation.py
@@ -437,7 +437,7 @@ def embargo(cv: BaseTimeSeriesCrossValidator, train_indices: np.ndarray,
     if not hasattr(cv, 'embargo_td'):
         raise ValueError("The passed cross-validation object should have a member cv.embargo_td defining the embargo"
                          "time.")
-    last_test_eval_time = cv.eval_times.iloc[test_indices[:test_fold_end]].max()
+    last_test_eval_time = cv.eval_times.iloc[test_indices[test_indices <= test_fold_end]].max()
     min_train_index = len(cv.pred_times[cv.pred_times <= last_test_eval_time + cv.embargo_td])
     if min_train_index < cv.indices.shape[0]:
         allowed_indices = np.concatenate((cv.indices[:test_fold_end], cv.indices[min_train_index:]))


### PR DESCRIPTION
Hello! First of all I would like to thank you so much for your repo! I'm currently doing my master's dissertation and wanted to utilize Combinatorial Purged CV and this was a lifesaver really, it helped me save so much time and thank you for that!

During my implementation I think I found a bug in the calculation of `last_test_eval_time`. After some debugging it appeared that the wrong index was being used to split the `test_indices` list resulting in always using the last 'eval_time' avaliable, causing folds like the following one, where the training data would be cut after a portion of the testing data like such:

![image](https://user-images.githubusercontent.com/21294062/119230582-cb54bb80-bb14-11eb-996f-b5f5908bb515.png)

I think my pull request solves this, as we can see here:
![image](https://user-images.githubusercontent.com/21294062/119230740-74031b00-bb15-11eb-8f36-0a105cb7a321.png)

It still embargoes correctly (as we can see by the gap after the test sets) but no longer but no longer clips the training data in between.

Hope it helps!